### PR TITLE
Fix the jslint issue in the promisify callback.

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -20,51 +20,48 @@ var Promise;
 // Use the ES6 Promise library by @jaffathecake
 Promise = require("es6-promise").Promise;
 
-// Default callback function - rejects on truthy error, otherwise resolves
-function defaultCallback(err, result) {
-    // These lines fail jslint :( because it looks like a strict-mode
-    // violation. If this function was called directly, that would be
-    // true -- but we only call this function with it bound to an
-    // appropriate context, so in practice this doesn't happen.  But
-    // jslint is right -- and if anyone can think of a better way to do
-    // it then send me a pull request!
-    // https://github.com/twistdigital/es6-promisify/issues
-    if (err) {
-        return this.reject(err);
-    }
-    this.resolve(result);
+// Promise Context object constructor.
+function Context(resolve, reject, custom) {
+    this.resolve = resolve;
+    this.reject = reject;
+    this.custom = custom;
 }
 
-module.exports = function (original, cb) {
+// Default callback function - rejects on truthy error, otherwise resolves
+function callback(ctx, err, result) {
+    if (typeof ctx.custom === 'function') {
+        var cust = function () {
+            // Bind the callback to itself, so the resolve and reject
+            // properties that we bound are available to the callback.
+            // Then we push it onto the end of the arguments array.
+            return ctx.custom.apply(cust, arguments);
+        };
+        cust.resolve = ctx.resolve;
+        cust.reject = ctx.reject;
+        cust.call(null, err, result);
+    } else {
+        if (err) {
+            return ctx.reject(err);
+        }
+        ctx.resolve(result);
+    }
+}
 
-    // If a callback is supplied, use it. Otherwise, use the default
-    var originalCallback = cb || defaultCallback;
+module.exports = function (original, custom) {
 
     return function () {
 
-        var callback, args;
-
-        callback = (function (callback) {
-            var newCallback = function () {
-                callback.apply(newCallback, arguments);
-            };
-            return newCallback;
-        }(originalCallback));
-
         // Parse out the original arguments
-        args = Array.prototype.slice.call(arguments);
+        var args = Array.prototype.slice.call(arguments);
 
         // Return the promisified function
         return new Promise(function (resolve, reject) {
 
-            // Attach the resolve and reject functions to the callback
-            callback.resolve = resolve;
-            callback.reject  = reject;
+            // Create a Context object
+            var ctx = new Context(resolve, reject, custom);
 
-            // Bind the callback to itself, so the resolve and reject
-            // properties that we bound are available to the callback.
-            // Then we push it onto the end of the arguments array.
-            args.push(callback.bind(callback));
+            // Append the callback bound to the context
+            args.push(callback.bind(null, ctx));
 
             // Call the function
             original.apply(original, args);


### PR DESCRIPTION
This commit also removes the callback trampoline from the common default
callback use case by using an explicit Context object instead of binding
resolve/reject to a cloned function object.
