### PR TITLE
Use native Promise when available.

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -17,8 +17,8 @@
 
 var Promise;
 
-// Use the ES6 Promise library by @jaffathecake
-Promise = require("es6-promise").Promise;
+// Use the ES6 Promise library by @jaffathecake when native Promise is not available
+Promise = global.Promise || require("es6-promise").Promise;
 
 // Promise Context object constructor.
 function Context(resolve, reject, custom) {


### PR DESCRIPTION
Tests run fine in both 0.10.29 and in 0.11.13.

I did not introduce any test for this, since it would need quite a lot of changes in the loading of modules in the current test suite.
